### PR TITLE
Key length comparison to fix ConstantTimeCompare quirk

### DIFF
--- a/argon2id.go
+++ b/argon2id.go
@@ -101,6 +101,12 @@ func ComparePasswordAndHash(password, hash string) (match bool, err error) {
 
 	otherKey := argon2.IDKey([]byte(password), salt, params.Iterations, params.Memory, params.Parallelism, params.KeyLength)
 
+	keyLen := int32(len(key))
+	otherKeyLen := int32(len(otherKey))
+
+	if subtle.ConstantTimeEq(keyLen, otherKeyLen) == 0 {
+		return false, nil
+	}
 	if subtle.ConstantTimeCompare(key, otherKey) == 1 {
 		return true, nil
 	}


### PR DESCRIPTION
According to this SO comment [1] and its attached source code, ConstantTimeCompare has a "subtle" behavior that could possible leak the length of compared data.

In order to fix this we should check both lengths using ConstantTimeEq.

[1]: https://stackoverflow.com/questions/20663468/secure-compare-of-strings-in-go#comment30964060_20663629