### PR TITLE
add CheckHash and export DecodeHash

### DIFF
--- a/argon2id_test.go
+++ b/argon2id_test.go
@@ -55,3 +55,36 @@ func TestComparePasswordAndHash(t *testing.T) {
 		t.Error("expected password and hash to not match")
 	}
 }
+
+func TestDecodeHash(t *testing.T) {
+	hash, err := CreateHash("pa$$word", DefaultParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params, _, _, err := DecodeHash(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *params != *DefaultParams {
+		t.Fatalf("expected %#v got %#v", *DefaultParams, *params)
+	}
+}
+
+func TestCheckHash(t *testing.T) {
+	hash, err := CreateHash("pa$$word", DefaultParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok, params, err := CheckHash("pa$$word", hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected password to match")
+	}
+	if *params != *DefaultParams {
+		t.Fatalf("expected %#v got %#v", *DefaultParams, *params)
+	}
+}


### PR DESCRIPTION
This change exports the function DecodeHash and adds a new function CheckHash, which returns
the parameters used to create the given hash. This is useful for real-world use of
argon2id hashing, where you should periodically upgrade the hashing parameters to keep
up with increasing processor speed. In order to do that, you need to get the parameters
a hash was saved with, to compare against your current gold standard.