### PR TITLE
replace Parallelism with number of cores

### DIFF
--- a/argon2id.go
+++ b/argon2id.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"golang.org/x/crypto/argon2"
@@ -45,7 +46,7 @@ var (
 var DefaultParams = &Params{
 	Memory:      64 * 1024,
 	Iterations:  1,
-	Parallelism: 2,
+	Parallelism: uint8(runtime.NumCPU()),
 	SaltLength:  16,
 	KeyLength:   32,
 }


### PR DESCRIPTION
Parallelism should not be hardcoded but should be dynamically set to the number of cores, that are available for the application.