### PR TITLE
replace Parallelism with number of cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ package main
 
 import (
 	"log"
+	"runtime"
 
 	"github.com/alexedwards/argon2id"
 )
@@ -56,7 +57,7 @@ If the code is running on a machine with multiple cores, then you can decrease t
 params := &argon2id.Params{
 	Memory:      128 * 1024,
 	Iterations:  4,
-	Parallelism: 4,
+	Parallelism: uint8(runtime.NumCPU()),
 	SaltLength:  16,
 	KeyLength:   32,
 }

--- a/argon2id.go
+++ b/argon2id.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"golang.org/x/crypto/argon2"
@@ -45,7 +46,7 @@ var (
 var DefaultParams = &Params{
 	Memory:      64 * 1024,
 	Iterations:  1,
-	Parallelism: 2,
+	Parallelism: uint8(runtime.NumCPU()),
 	SaltLength:  16,
 	KeyLength:   32,
 }


### PR DESCRIPTION
Parallelism should not be hardcoded but should be dynamically set to the number of cores, that are available for the application.
Also update README.